### PR TITLE
Remove scrollbar

### DIFF
--- a/CSS/main.css
+++ b/CSS/main.css
@@ -12,6 +12,12 @@ body {
     font-family: 'Work Sans', sans-serif;
     min-height: 100vh;
     padding-top: 3%;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+body::-webkit-scrollbar {
+    display: none;
 }
 
 /* Body light or darker themes */


### PR DESCRIPTION
I noticed that when deleting a task, the task falls and scrollbar appears. The scrollbar shrinks the page for a moment which does not look good. So I hid it from the body tag. I know this approach is not good for accessibility but it would help the webpage look nicer. 